### PR TITLE
Enable Oauth2 implicit grants and supplemental redirect_uris.

### DIFF
--- a/src/Two/AbstractProvider.php
+++ b/src/Two/AbstractProvider.php
@@ -177,6 +177,16 @@ abstract class AbstractProvider implements ProviderContract
     {
         $session = $this->request->getSession();
 
+        if($this->request->has('code')) {
+
+            if($redirectUri = $this->request->get('redirect_uri')) {
+                $this->redirectUrl = $redirectUri;
+            }
+
+            return false;
+
+        }
+
         return ! ($this->request->input('state') === $session->get('state'));
     }
 


### PR DESCRIPTION
By allowing the current request to be seen as valid when the `code` parameter when present, Socialite continues the flow naturally.  Also, the option to supply an alternate `redirect_uri` is made available.  This is necessary so that the server can claim the code.